### PR TITLE
Fix Chrome bug

### DIFF
--- a/_dotted-border.scss
+++ b/_dotted-border.scss
@@ -8,12 +8,12 @@
 @mixin dottedBorder($color: #8f8f8f, $orientation: horizontal, $position: top, $spacing: 5px, $size: 1px) {
   background-position: $position;
   @if $orientation == horizontal {
-    background-image: linear-gradient(to right, $color $size/$spacing, rgba(255,255,255,0) 0%);
+    background-image: linear-gradient(to right, $color $size/$spacing * 100%, rgba(255,255,255,0) 0%);
     background-size: $spacing $size;
     background-repeat: repeat-x;
   }
   @else {
-    background-image: linear-gradient($color $size/$spacing, rgba(255,255,255,0) 0%);
+    background-image: linear-gradient($color $size/$spacing * 100%, rgba(255,255,255,0) 0%);
     background-size: $size $spacing;
     background-repeat: repeat-y;
   }


### PR DESCRIPTION
The `linear-gradient` part doesn't work in Chrome because it expects a percentage value instead of a decimal.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/florbraz/dotted-border-w-custom-spacing-scss-mixin/1)

<!-- Reviewable:end -->
